### PR TITLE
unlock new buildings & adjust for tracking failure

### DIFF
--- a/RELEASE/scripts/crimbo/crimbo21.ash
+++ b/RELEASE/scripts/crimbo/crimbo21.ash
@@ -38,6 +38,15 @@ void crimbo_quest_start()
 	}
 	
 	spam_url("place.php?whichplace=crimbo21&action=c21_abuela");
+	visit_url("place.php?whichplace=northpole");
+	spam_url("place.php?whichplace=northpole&action=np_bonfire");
+	
+	visit_url("place.php?whichplace=northpole&action=np_sauna");
+	run_choice(2);	//leave
+	spam_url("place.php?whichplace=northpole&action=np_bonfire");
+	
+	visit_url("place.php?whichplace=northpole&action=np_foodlab");
+	run_choice(2);	//leave
 	spam_url("place.php?whichplace=northpole&action=np_bonfire");
 	
 	set_property("_crimbo21_quest_started", true);

--- a/RELEASE/scripts/crimbo/crimbo21.ash
+++ b/RELEASE/scripts/crimbo/crimbo21.ash
@@ -91,7 +91,24 @@ int coldness()
 	//[Site Alpha Dormitory] has scaling cold res requirement. starting at 5 and increased by 1 every 3 adv spent there.
 	//there seems to be some unreliability on this value so add 1 to the final value
 	int visits = get_property("_crimbo21_greenhouse").to_int() + get_property("_crimbo21_dormitory").to_int();
-	return 6 + (visits / 3);
+	int adjust = get_property("_crimbo21_cold_adjust").to_int();
+	return 6 + (visits / 3) + adjust;
+}
+
+void coldness_correction()
+{
+	//if coldness becomes desynced we need to fix it with an adjustment value
+	int actual_coldness = get_property("_crimbo21ColdResistance").to_int();
+	if(actual_coldness == 0)
+	{
+		return;		//nothing to fix yet
+	}
+	
+	int predicted_value = (get_property("_crimbo21_greenhouse").to_int() + get_property("_crimbo21_dormitory").to_int()) / 3;
+	predicted_value += 5;
+	int diff = actual_coldness - predicted_value;
+	set_property("_crimbo21_cold_adjust", diff);
+	remove_property("_crimbo21ColdResistance");
 }
 
 void visit_sauna()
@@ -162,6 +179,7 @@ void main(int adv_to_use)
 	}
 	crimbo_settings_defaults();
 	crimbo_quest_start();
+	coldness_correction();
 	
 	backupSetting("printStackOnAbort", true);
 	backupSetting("promptAboutCrafting", 0);


### PR DESCRIPTION
unlock new buildings at quest start
if coldness tracking fail, fix it and adjust for the erroneous data