### PR TITLE
user specified ratio and free combats

### DIFF
--- a/BUILD/settings/crimbo21.dat
+++ b/BUILD/settings/crimbo21.dat
@@ -1,1 +1,4 @@
 #crimbo21 specific settings
+crimbo21_ratio_animal	int	The ratio priority for gooified animal matter. will determine how often we adv in dormitory. set to 0 to disable dormitory
+crimbo21_ratio_vegetable	int	The ratio priority for gooified vegetable matter. will determine how often we adv in greenhouse. set to 0 to disable greenhouse
+crimbo21_ratio_mineral	int	The ratio priority for gooified mineral matter. will determine how often we adv in quarry. set to 0 to disable quarry

--- a/BUILD/settings/crimbo21.dat
+++ b/BUILD/settings/crimbo21.dat
@@ -1,4 +1,4 @@
 #crimbo21 specific settings
-crimbo21_ratio_animal	int	The ratio priority for gooified animal matter. will determine how often we adv in dormitory. set to 0 to disable dormitory
-crimbo21_ratio_vegetable	int	The ratio priority for gooified vegetable matter. will determine how often we adv in greenhouse. set to 0 to disable greenhouse
-crimbo21_ratio_mineral	int	The ratio priority for gooified mineral matter. will determine how often we adv in quarry. set to 0 to disable quarry
+crimbo21_ratio_animal	int	The ratio priority for gooified animal matter. will determine how often we adv in dormitory. less than 1 disables dormitory
+crimbo21_ratio_vegetable	int	The ratio priority for gooified vegetable matter. will determine how often we adv in greenhouse. less than 1 disables greenhouse
+crimbo21_ratio_mineral	int	The ratio priority for gooified mineral matter. will determine how often we adv in quarry. less than 1 disables quarry

--- a/RELEASE/data/crimbo_settings.txt
+++ b/RELEASE/data/crimbo_settings.txt
@@ -7,7 +7,7 @@
 crimbo	0	crimbo_do_free_combats	boolean	should we use up free combats before starting on crimbo. By default this is off.
 
 #crimbo21 specific settings
-crimbo21	0	crimbo21_ratio_animal	int	The ratio priority for gooified animal matter. will determine how often we adv in dormitory. set to 0 to disable dormitory
-crimbo21	1	crimbo21_ratio_vegetable	int	The ratio priority for gooified vegetable matter. will determine how often we adv in greenhouse. set to 0 to disable greenhouse
-crimbo21	2	crimbo21_ratio_mineral	int	The ratio priority for gooified mineral matter. will determine how often we adv in quarry. set to 0 to disable quarry
+crimbo21	0	crimbo21_ratio_animal	int	The ratio priority for gooified animal matter. will determine how often we adv in dormitory. less than 1 disables dormitory
+crimbo21	1	crimbo21_ratio_vegetable	int	The ratio priority for gooified vegetable matter. will determine how often we adv in greenhouse. less than 1 disables greenhouse
+crimbo21	2	crimbo21_ratio_mineral	int	The ratio priority for gooified mineral matter. will determine how often we adv in quarry. less than 1 disables quarry
 

--- a/RELEASE/data/crimbo_settings.txt
+++ b/RELEASE/data/crimbo_settings.txt
@@ -3,7 +3,11 @@
 
 # variable timing, number, variable name, variable type, description
 
+#crimbo shared settings
 crimbo	0	crimbo_do_free_combats	boolean	should we use up free combats before starting on crimbo. By default this is off.
 
 #crimbo21 specific settings
+crimbo21	0	crimbo21_ratio_animal	int	The ratio priority for gooified animal matter. will determine how often we adv in dormitory. set to 0 to disable dormitory
+crimbo21	1	crimbo21_ratio_vegetable	int	The ratio priority for gooified vegetable matter. will determine how often we adv in greenhouse. set to 0 to disable greenhouse
+crimbo21	2	crimbo21_ratio_mineral	int	The ratio priority for gooified mineral matter. will determine how often we adv in quarry. set to 0 to disable quarry
 

--- a/RELEASE/scripts/crimbo/crimbo21.ash
+++ b/RELEASE/scripts/crimbo/crimbo21.ash
@@ -153,6 +153,11 @@ boolean crimbo_loop()
 	
 	resetState();
 	
+	if(get_property("crimbo_do_free_combats").to_boolean())
+	{
+		if(LX_freeCombats(true)) return true;
+	}
+	
 	//cold res buffs
 	horsePale();	//we want the cold res
 	buffMaintain($effect[Astral shell], 0, 1, 1);


### PR DESCRIPTION
* crimbo can now do free combats too based on setting (default off)
* determine where to adventure based on user provided ratio of gooefied items to hoard