### PR TITLE
do not disable mood

### DIFF
--- a/BUILD/settings/crimbo21.dat
+++ b/BUILD/settings/crimbo21.dat
@@ -2,5 +2,5 @@
 crimbo21_ratio_animal	int	The ratio priority for gooified animal matter. will determine how often we adv in dormitory. less than 1 disables dormitory
 crimbo21_ratio_vegetable	int	The ratio priority for gooified vegetable matter. will determine how often we adv in greenhouse. less than 1 disables greenhouse
 crimbo21_ratio_mineral	int	The ratio priority for gooified mineral matter. will determine how often we adv in quarry. less than 1 disables quarry
-crimbo21_food	boolean	Set to True to automatically make and consume the food at the EPIC quality experimental food
-crimbo21_drink	boolean	Set to True to automatically make and consume the drink at the good quality experimental drink
+crimbo21_food	boolean	Set to True to automatically make and consume the EPIC quality experimental crimbo food
+crimbo21_drink	boolean	Set to True to automatically make and consume the good quality experimental crimbo drink

--- a/RELEASE/data/crimbo_settings.txt
+++ b/RELEASE/data/crimbo_settings.txt
@@ -10,6 +10,6 @@ crimbo	0	crimbo_do_free_combats	boolean	should we use up free combats before sta
 crimbo21	0	crimbo21_ratio_animal	int	The ratio priority for gooified animal matter. will determine how often we adv in dormitory. less than 1 disables dormitory
 crimbo21	1	crimbo21_ratio_vegetable	int	The ratio priority for gooified vegetable matter. will determine how often we adv in greenhouse. less than 1 disables greenhouse
 crimbo21	2	crimbo21_ratio_mineral	int	The ratio priority for gooified mineral matter. will determine how often we adv in quarry. less than 1 disables quarry
-crimbo21	3	crimbo21_food	boolean	Set to True to automatically make and consume the food at the EPIC quality experimental food
-crimbo21	4	crimbo21_drink	boolean	Set to True to automatically make and consume the drink at the good quality experimental drink
+crimbo21	3	crimbo21_food	boolean	Set to True to automatically make and consume the EPIC quality experimental crimbo food
+crimbo21	4	crimbo21_drink	boolean	Set to True to automatically make and consume the good quality experimental crimbo drink
 

--- a/RELEASE/scripts/crimbo/crimbo21.ash
+++ b/RELEASE/scripts/crimbo/crimbo21.ash
@@ -356,7 +356,6 @@ void main(int adv_to_use)
 	backupSetting("recoveryScript", "");
 	backupSetting("counterScript", "");
 	backupSetting("battleAction", "custom combat script");
-	backupSetting("currentMood", "apathetic");
 	backupSetting("logPreferenceChange", "true");
 	backupSetting("logPreferenceChangeFilter", "maximizerMRUList,testudinalTeachings,auto_maximize_current");
 	


### PR DESCRIPTION
do not disable mood while running. allowing user to specify a cold res mood for additional effects that are not currently automated by the script